### PR TITLE
Fix for info() command

### DIFF
--- a/src/Seeed_Arduino_SSCMA.cpp
+++ b/src/Seeed_Arduino_SSCMA.cpp
@@ -565,7 +565,7 @@ int SSCMA::wait(int type, const char *cmd, uint32_t timeout)
 
                 ret = response["code"];
 
-                if (response["type"] == type && strcmp(response["name"], cmd) == 0)
+                if (response["type"] == type && strncmp(response["name"], cmd, sizeof(cmd)) == 0)
                 {
                     return ret;
                 }


### PR DESCRIPTION
A fix for info command as the type is 0 and it tries to compare with a response that has the ? in the command, but the consts do not.  So this will compare only the size of the command